### PR TITLE
Add platform for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS codeql_base
+FROM --platform=amd64 ubuntu:20.04 AS codeql_base
 LABEL maintainer="CodeQL Agent Community" 
 # Please note that we are a non-profit organization and are not the official team of CodeQL. Please follow the license of CodeQL CLI.
 


### PR DESCRIPTION
Solution for issue #1, tested successfully on a Mac with M1 chip, running version 14.1.1.