### PR TITLE
Customizable JDK and Maven Versions for CodeQL Agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && \
     	file \
         dos2unix \
         default-jdk \
-		openjdk-8-jdk \
 		maven \
     	gettext && \
         apt-get clean && \

--- a/Dockerfile-java
+++ b/Dockerfile-java
@@ -1,0 +1,12 @@
+# FROM --platform=amd64 maven:3.8-openjdk-17-slim
+FROM --platform=amd64 maven:3-jdk-8-slim
+
+RUN ls -lia $JAVA_HOME
+
+RUN mkdir -p /opt/jdk/ /opt/maven/
+
+RUN cp -r $JAVA_HOME/* /opt/jdk/
+
+RUN cp -r $MAVEN_HOME/* /opt/maven/
+
+CMD ["echo"]


### PR DESCRIPTION
## Changes Proposed

This pull request introduces the ability to customize the Java and Maven versions used within the CodeQL agent's Docker image. The changes allow users to mount a volume with different versions of JDK and Maven and set the appropriate environment variables in the CodeQL agent container.

### Why this change?
Using fixed versions of JDK and Maven can limit the CodeQL agent's applicability to projects that require specific versions. By allowing customization, we enable users to analyze code that may not be compatible with the default versions of these tools.

