### PR TITLE
add missing supported language "ruby" to analyze.sh

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -79,7 +79,7 @@ fi
 
 # Set options
 LANGUAGE=${LANGUAGE,,}
-if [[ "$LANGUAGE" == "python" || "$LANGUAGE" == "javascript" || "$LANGUAGE" == "cpp" || "$LANGUAGE" == "csharp" || "$LANGUAGE" == "java" || "$LANGUAGE" == "go" || "$LANGUAGE" == "typescript" || "$LANGUAGE" == "c" ]]; then
+if [[ "$LANGUAGE" == "python" || "$LANGUAGE" == "javascript" || "$LANGUAGE" == "cpp" || "$LANGUAGE" == "csharp" || "$LANGUAGE" == "java" || "$LANGUAGE" == "go" || "$LANGUAGE" == "typescript" || "$LANGUAGE" == "c"  || "$LANGUAGE" == "ruby" ]]; then
     if [[ "$LANGUAGE" == "typescript" ]]; then
         LANGUAGE="javascript"
     fi


### PR DESCRIPTION
Ruby is already included in `SupportedLanguage` and works fine when I tested it. But it's being incorrectly denied as an "Invalid language" due to this check. 